### PR TITLE
fix : 회원가입 이메일 유효성 수정

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,6 +1,6 @@
 export const checkEmail = (email) => {
-  const emailRegex = /^[A-Za-z0-9]([-_.]?[A-Za-z0-9])*@[A-Za-z0-9]([-_.]?[A-Za-z0-9])*\.[A-Za-z]{2,3}$/i;
-
+  const emailRegex =
+    /(^[-_.]?[0-9a-zA-Z])([-_.]?[0-9a-zA-Z][-_.]?)*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
   return emailRegex.test(email);
 };
 


### PR DESCRIPTION
문제 : 이메일 유효성 중 _ 사용이 안된다는 피드백을 받고 확인하니 이메일의 아이디 부분에서 중간에 _ 가 있으면 가능하지만 시작이나 끝부분에 _ 가 있으면 안되는 현상
해결 : _를 이메일 아이디부분 앞이나 중간이나 끝에 가능하게 수정